### PR TITLE
fix: #31 footprint.py --warp PATH (reuse precomputed SIFT)

### DIFF
--- a/skills/nanodevice_flakedetect_align/SKILL.md
+++ b/skills/nanodevice_flakedetect_align/SKILL.md
@@ -222,6 +222,7 @@ Optional:
 - `--source-contour` + `--source-mask` — use pre-computed contour/mask from source_contour.py instead of re-segmenting internally. **Recommended**: ensures footprint uses the same source shape as sweep/refine.
 - `--n-clusters N` — number of K-means clusters (default: 12; increase for finer segmentation on retry)
 - `--candidate-rank N` — use the Nth-ranked candidate instead of the default (#1). **Always check `03_footprint_candidates.png`** — candidate #1 is often wrong. Try `--candidate-rank 2` or `--candidate-rank 3` on retry.
+- `--warp <path-to-warp_sift_bottom.npy>` — reuse the SIFT warp produced by `sift_align.py` instead of re-running SIFT internally (issue #31). If omitted, auto-resolves `<output-dir>/warp_sift_bottom.npy` then `<source-parent>/../align/warp_sift_bottom.npy`. Internal SIFT only runs when neither path exists. Sibling scripts (`sweep.py`, `refine.py`, `source_contour.py`) do not run SIFT internally and need no equivalent flag.
 
 **Outputs**: `footprint_mask.png`, `footprint_contour.npy`, `02_diff_image.png`, `02_cluster_map.png`, `03_footprint_candidates.png`, `04_footprint_grabcut.png`, updates `alignment_report.json`
 

--- a/skills/nanodevice_flakedetect_align/scripts/footprint.py
+++ b/skills/nanodevice_flakedetect_align/scripts/footprint.py
@@ -22,7 +22,15 @@ Usage:
     conda run -n instrMCPdev python footprint.py \
         --source <source_image> --target <target_image> \
         --bottom <bottom_part_image> \
-        [--mirror] --pixel-size <um/px> --output-dir <path>
+        [--mirror] --pixel-size <um/px> --output-dir <path> \
+        [--warp <warp_sift_bottom.npy>]
+
+Warp resolution (issue #31):
+    If --warp PATH is given, the precomputed bottom->target warp is loaded
+    via np.load(PATH) and the internal SIFT pass is skipped. If --warp is
+    omitted, footprint.py looks for a precomputed warp at
+    <output-dir>/warp_sift_bottom.npy and at <source-dir>/../align/
+    warp_sift_bottom.npy before falling back to running SIFT internally.
 """
 
 import argparse
@@ -96,6 +104,40 @@ def sift_align(bottom_img, target_img, n_features=5000, ratio_thresh=0.7):
                                            ransacReprojThreshold=5.0)
     n_inliers = int(mask.sum()) if mask is not None else 0
     return M, n_inliers
+
+
+def resolve_warp_path(explicit_path, output_dir, source_path):
+    """Resolve the path of a precomputed bottom->target SIFT warp.
+
+    Priority (issue #31):
+      1. --warp PATH (if given and exists)
+      2. <output_dir>/warp_sift_bottom.npy
+      3. <parent_of_source_dir>/align/warp_sift_bottom.npy
+    Returns (path, source_tag) or (None, None) if no candidate exists.
+    """
+    if explicit_path:
+        if os.path.exists(explicit_path):
+            return explicit_path, "--warp"
+        return None, None
+    cand1 = os.path.join(output_dir, "warp_sift_bottom.npy")
+    if os.path.exists(cand1):
+        return cand1, "output_dir"
+    src_parent = os.path.dirname(os.path.abspath(source_path))
+    cand2 = os.path.join(os.path.dirname(src_parent), "align",
+                         "warp_sift_bottom.npy")
+    if os.path.exists(cand2):
+        return cand2, "source_parent/align"
+    return None, None
+
+
+def load_warp_matrix(path):
+    """Load and validate a 2x3 affine warp matrix from .npy."""
+    M = np.load(path)
+    if M.shape != (2, 3):
+        raise ValueError(
+            f"warp matrix at {path} has shape {M.shape}, expected (2, 3)"
+        )
+    return M.astype(np.float64)
 
 
 def compute_diff_image(target_bgr, bottom_bgr, warp_matrix):
@@ -481,6 +523,13 @@ def main():
     parser.add_argument("--n-clusters", type=int, default=12)
     parser.add_argument("--candidate-rank", type=int, default=1)
     parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--warp", default=None,
+        help="Path to precomputed bottom->target SIFT warp (.npy). "
+             "If omitted, footprint.py auto-resolves "
+             "<output-dir>/warp_sift_bottom.npy or "
+             "<source-parent>/../align/warp_sift_bottom.npy. "
+             "Only runs SIFT internally when neither path resolves (#31).")
     args = parser.parse_args()
 
     source_img = cv2.imread(args.source)
@@ -524,15 +573,36 @@ def main():
     source_area = source_desc["area"]
     print(f"[B1] Source flake area={source_area:.0f}px")
 
-    # SIFT, diff, K-means
-    print("[B1] SIFT-aligning bottom to target...")
-    warp_matrix, n_inliers = sift_align(bottom_img, target_img)
-    if warp_matrix is None:
-        emit_failure(report_path, f"sift alignment failed ({n_inliers} matches)",
+    # SIFT (or precomputed warp via --warp / auto-lookup; #31)
+    warp_path, warp_src = resolve_warp_path(
+        args.warp, args.output_dir, args.source
+    )
+    if args.warp and warp_path is None:
+        emit_failure(report_path,
+                     f"--warp path not found: {args.warp}",
                      target_h, target_w)
-        print(f"ERROR: SIFT alignment failed ({n_inliers}).", file=sys.stderr)
+        print(f"ERROR: --warp path not found: {args.warp}", file=sys.stderr)
         sys.exit(1)
-    print(f"[B1] SIFT: {n_inliers} inliers")
+    if warp_path is not None:
+        try:
+            warp_matrix = load_warp_matrix(warp_path)
+        except (ValueError, OSError) as e:
+            emit_failure(report_path, f"cannot load warp {warp_path}: {e}",
+                         target_h, target_w)
+            print(f"ERROR: Cannot load warp {warp_path}: {e}", file=sys.stderr)
+            sys.exit(1)
+        print(f"[B1] Reusing precomputed SIFT warp from {warp_src}: {warp_path}")
+    else:
+        print("[B1] SIFT-aligning bottom to target...")
+        warp_matrix, n_inliers = sift_align(bottom_img, target_img)
+        if warp_matrix is None:
+            emit_failure(report_path,
+                         f"sift alignment failed ({n_inliers} matches)",
+                         target_h, target_w)
+            print(f"ERROR: SIFT alignment failed ({n_inliers}).",
+                  file=sys.stderr)
+            sys.exit(1)
+        print(f"[B1] SIFT: {n_inliers} inliers")
 
     diff_gray = compute_diff_image(target_img, bottom_img, warp_matrix)
     cv2.imwrite(os.path.join(args.output_dir, "02_diff_image.png"), diff_gray)

--- a/tests/test_footprint_warp.py
+++ b/tests/test_footprint_warp.py
@@ -1,0 +1,233 @@
+"""Unit tests for issue #31: footprint.py --warp PATH reuses precomputed SIFT warp.
+
+Asserts:
+- Passing --warp <path-to-known-warp.npy> skips the internal SIFT pass.
+- The matrix loaded from disk matches what footprint.py uses for the diff stage.
+- Auto-lookup falls back to <output_dir>/warp_sift_bottom.npy when --warp omitted.
+- Internal SIFT is only invoked when neither --warp nor a default path resolves.
+
+Run:
+    conda run -n instrMCPdev python -m pytest tests/test_footprint_warp.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+import cv2
+import numpy as np
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+FOOTPRINT_PATH = os.path.join(
+    REPO_ROOT, "skills", "nanodevice_flakedetect_align", "scripts", "footprint.py"
+)
+
+
+def _import_footprint():
+    """Import footprint.py as a module without running argparse."""
+    # core.py lives in the flakedetect skill; footprint.py adds it to sys.path
+    spec = importlib.util.spec_from_file_location("footprint_mod", FOOTPRINT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestResolveWarpPath(unittest.TestCase):
+    """resolve_warp_path() priority: --warp > output_dir > source_parent/align."""
+
+    def setUp(self):
+        self.mod = _import_footprint()
+        self.tmp = tempfile.mkdtemp(prefix="footprint_warp_")
+        # Layout:
+        #   tmp/runs/align/warp_sift_bottom.npy   (source_parent/align candidate)
+        #   tmp/runs/source/top_part.png          (source image)
+        #   tmp/output/warp_sift_bottom.npy       (output_dir candidate)
+        os.makedirs(os.path.join(self.tmp, "runs", "align"))
+        os.makedirs(os.path.join(self.tmp, "runs", "source"))
+        os.makedirs(os.path.join(self.tmp, "output"))
+        self.source_path = os.path.join(self.tmp, "runs", "source", "top_part.png")
+        cv2.imwrite(self.source_path, np.zeros((10, 10, 3), dtype=np.uint8))
+
+    def _write_warp(self, path, value):
+        m = np.array([[value, 0.0, 0.0], [0.0, value, 0.0]], dtype=np.float64)
+        np.save(path, m)
+        return m
+
+    def test_explicit_warp_takes_priority(self):
+        explicit = os.path.join(self.tmp, "explicit_warp.npy")
+        self._write_warp(explicit, 1.0)
+        # Decoy at output dir + source_parent/align should NOT be selected
+        self._write_warp(os.path.join(self.tmp, "output", "warp_sift_bottom.npy"), 2.0)
+        self._write_warp(os.path.join(self.tmp, "runs", "align", "warp_sift_bottom.npy"), 3.0)
+        path, src = self.mod.resolve_warp_path(
+            explicit_path=explicit,
+            output_dir=os.path.join(self.tmp, "output"),
+            source_path=self.source_path,
+        )
+        self.assertEqual(path, explicit)
+        self.assertEqual(src, "--warp")
+
+    def test_explicit_missing_returns_none(self):
+        path, src = self.mod.resolve_warp_path(
+            explicit_path="/no/such/warp.npy",
+            output_dir=os.path.join(self.tmp, "output"),
+            source_path=self.source_path,
+        )
+        self.assertIsNone(path)
+        self.assertIsNone(src)
+
+    def test_output_dir_lookup(self):
+        out_warp = os.path.join(self.tmp, "output", "warp_sift_bottom.npy")
+        self._write_warp(out_warp, 1.0)
+        # Source-parent decoy should be skipped (output_dir wins)
+        self._write_warp(os.path.join(self.tmp, "runs", "align", "warp_sift_bottom.npy"), 9.0)
+        path, src = self.mod.resolve_warp_path(
+            explicit_path=None,
+            output_dir=os.path.join(self.tmp, "output"),
+            source_path=self.source_path,
+        )
+        self.assertEqual(path, out_warp)
+        self.assertEqual(src, "output_dir")
+
+    def test_source_parent_align_lookup(self):
+        align_warp = os.path.join(self.tmp, "runs", "align", "warp_sift_bottom.npy")
+        self._write_warp(align_warp, 1.0)
+        path, src = self.mod.resolve_warp_path(
+            explicit_path=None,
+            output_dir=os.path.join(self.tmp, "output"),
+            source_path=self.source_path,
+        )
+        self.assertEqual(path, align_warp)
+        self.assertEqual(src, "source_parent/align")
+
+    def test_no_candidate_returns_none(self):
+        path, src = self.mod.resolve_warp_path(
+            explicit_path=None,
+            output_dir=os.path.join(self.tmp, "output"),
+            source_path=self.source_path,
+        )
+        self.assertIsNone(path)
+        self.assertIsNone(src)
+
+
+class TestLoadWarpMatrix(unittest.TestCase):
+    """load_warp_matrix() returns the same matrix that np.save wrote."""
+
+    def setUp(self):
+        self.mod = _import_footprint()
+        self.tmp = tempfile.mkdtemp(prefix="footprint_loadwarp_")
+
+    def test_roundtrip(self):
+        path = os.path.join(self.tmp, "w.npy")
+        original = np.array(
+            [[1.0023, -0.0114, 12.5], [0.0114, 1.0023, -7.25]],
+            dtype=np.float64,
+        )
+        np.save(path, original)
+        loaded = self.mod.load_warp_matrix(path)
+        np.testing.assert_array_equal(loaded, original)
+
+    def test_rejects_wrong_shape(self):
+        path = os.path.join(self.tmp, "bad.npy")
+        np.save(path, np.eye(3))
+        with self.assertRaises(ValueError):
+            self.mod.load_warp_matrix(path)
+
+
+class TestFootprintSkipsSiftWhenWarpProvided(unittest.TestCase):
+    """End-to-end: footprint.py --warp PATH must NOT call sift_align internally.
+
+    We monkeypatch sift_align to a sentinel that raises if called, then run
+    main() far enough to hit the SIFT branch. The internal pipeline failing
+    later (no real flake in our synthetic image) is fine — what matters is
+    that sift_align was never invoked.
+    """
+
+    def setUp(self):
+        self.mod = _import_footprint()
+        self.tmp = tempfile.mkdtemp(prefix="footprint_e2e_")
+        # Synthesise tiny BGR images that cv2.imread can read back
+        self.src = os.path.join(self.tmp, "top_part.png")
+        self.tgt = os.path.join(self.tmp, "full_stack.png")
+        self.bot = os.path.join(self.tmp, "bottom_part.png")
+        cv2.imwrite(self.src, np.full((64, 64, 3), 200, dtype=np.uint8))
+        cv2.imwrite(self.tgt, np.full((64, 64, 3), 100, dtype=np.uint8))
+        cv2.imwrite(self.bot, np.full((64, 64, 3), 100, dtype=np.uint8))
+
+        self.outdir = os.path.join(self.tmp, "out")
+        os.makedirs(self.outdir)
+
+        # Known warp matrix (identity)
+        self.warp_path = os.path.join(self.tmp, "warp_sift_bottom.npy")
+        self.expected = np.array(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64
+        )
+        np.save(self.warp_path, self.expected)
+
+        # Pre-computed source contour/mask so segment_source_flake() is
+        # bypassed — keeps the test focused on the SIFT-skip behaviour.
+        sm = np.zeros((64, 64), dtype=np.uint8)
+        cv2.rectangle(sm, (16, 16), (48, 48), 255, -1)
+        self.src_mask_path = os.path.join(self.tmp, "src_mask.png")
+        cv2.imwrite(self.src_mask_path, sm)
+        cnt = np.array(
+            [[[16, 16]], [[48, 16]], [[48, 48]], [[16, 48]]], dtype=np.int32
+        )
+        self.src_contour_path = os.path.join(self.tmp, "src_contour.npy")
+        np.save(self.src_contour_path, cnt)
+
+    def test_warp_arg_skips_sift(self):
+        called = {"sift": False, "warp_matrix_seen": None}
+
+        def fake_sift(*a, **kw):
+            called["sift"] = True
+            raise AssertionError("sift_align must NOT be invoked when --warp is provided")
+
+        # Capture the warp_matrix that the diff stage receives
+        real_diff = self.mod.compute_diff_image
+
+        def spy_diff(target_bgr, bottom_bgr, warp_matrix):
+            called["warp_matrix_seen"] = np.array(warp_matrix, copy=True)
+            return real_diff(target_bgr, bottom_bgr, warp_matrix)
+
+        self.mod.sift_align = fake_sift
+        self.mod.compute_diff_image = spy_diff
+
+        argv = [
+            "footprint.py",
+            "--source", self.src,
+            "--target", self.tgt,
+            "--bottom", self.bot,
+            "--source-contour", self.src_contour_path,
+            "--source-mask", self.src_mask_path,
+            "--pixel-size", "0.1",
+            "--output-dir", self.outdir,
+            "--warp", self.warp_path,
+        ]
+        old_argv = sys.argv
+        sys.argv = argv
+        try:
+            try:
+                self.mod.main()
+            except SystemExit:
+                # Pipeline will exit somewhere downstream of SIFT on synthetic
+                # input; that's fine for this test.
+                pass
+        finally:
+            sys.argv = old_argv
+
+        self.assertFalse(called["sift"], "sift_align should not have been called")
+        self.assertIsNotNone(
+            called["warp_matrix_seen"],
+            "compute_diff_image was never called — pipeline bailed before "
+            "reaching the warp consumer; check resolve_warp_path wiring."
+        )
+        np.testing.assert_array_equal(called["warp_matrix_seen"], self.expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #31.

`footprint.py` previously re-ran SIFT internally with hard-coded defaults that could disagree with the upstream `sift_align.py` call — a stack with 60 inliers in `sift_align.py` could fail `footprint.py`'s redo at 9 inliers and abort the whole pipeline (QH10 evidence in the issue). This PR adds `--warp PATH` so the precomputed bottom->target warp is reused. When omitted, footprint.py auto-resolves `<output_dir>/warp_sift_bottom.npy`, then `<source_parent>/../align/warp_sift_bottom.npy`; internal SIFT runs only when neither path exists. B1's black-border padding + quality-gate retry are preserved untouched.

Audited the three sibling scripts (`sweep.py`, `refine.py`, `source_contour.py`) — none invoke `sift_align` internally, so no equivalent flag is needed there. Documented in `SKILL.md`.

## Test plan
- [x] `tests/test_footprint_warp.py` (8 cases) — `conda run -n instrMCPdev python -m pytest tests/test_footprint_warp.py -v` -> 8 passed
  - `resolve_warp_path` priority: `--warp` > `output_dir` > `source_parent/align` > `None`
  - `load_warp_matrix` shape validation + numeric round-trip
  - E2E: `footprint.py --warp <path>` skips `sift_align` (monkeypatched to raise) and feeds the loaded matrix verbatim into `compute_diff_image`
- [x] `--help` lists the new `--warp` argument
- [x] `grep` confirms B1 functions (`black_border_pad`, `crop_border`, `grabcut_with_quality_retry`) still present and called from `main()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)