### PR TITLE
fix: #25 + #34 server tool list cleanup + route_inspect crossings image

### DIFF
--- a/plugin/klayoutclaw_server.lym
+++ b/plugin/klayoutclaw_server.lym
@@ -330,7 +330,7 @@ TOOLS = [
     },
     {
         "name": "route_inspect",
-        "description": "Inspect every route on a given layer and report (route_id, from_contact, to_pad, length_um, layer, endpoints_um) plus any pair crossings. route_id matches the indexing used by evaluate_design's contact_isolation.crossing_pairs so the two tools can be cross-referenced. Read-only \u2014 never modifies the layout.",
+        "description": "Inspect every route on a given layer and report (route_id, from_contact, to_pad, length_um, layer, endpoints_um) plus any pair crossings. route_id matches the indexing used by evaluate_design's contact_isolation.crossing_pairs so the two tools can be cross-referenced. When crossings are detected, also renders a labeled PNG of the crossing region (zoom_box around all crossing geometries with 10x line-width clearance, route_id printed near both endpoints of each crossing-involved route); the path is returned in the 'image_path' field. Read-only \u2014 never modifies the layout.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -341,7 +341,8 @@ TOOLS = [
                     "description": "Layer specs for contact shapes that route endpoints may land on. Accepts a list of layer specs. Required — there is no default."
                 },
                 "pad_layer": {"type": "string", "description": "Layer spec for bonding pads. Required — there is no default."},
-                "tolerance_um": {"type": "number", "description": "Endpoint-to-shape matching tolerance in microns (default 5.0).", "default": 5.0}
+                "tolerance_um": {"type": "number", "description": "Endpoint-to-shape matching tolerance in microns (default 5.0).", "default": 5.0},
+                "image_path": {"type": "string", "description": "Optional output PNG path for the labeled-crossings image. Defaults to /tmp/route_inspect_&lt;ts&gt;.png. Only written when crossings are detected; with no crossings the response field 'image_path' is null."}
             },
             "required": ["route_layer", "contact_layers", "pad_layer"]
         }
@@ -1006,6 +1007,15 @@ def _tool_route_inspect(args):
             "pads). No default is assumed.")
     tolerance_um = float(args.get("tolerance_um", 5.0))
 
+    # Issue #34: optional labeled-crossings PNG. Default path uses an
+    # epoch timestamp so successive calls don't clobber prior output.
+    import time as _time
+    image_path_arg = args.get("image_path")
+    if image_path_arg:
+        labeled_image_path = os.path.abspath(str(image_path_arg))
+    else:
+        labeled_image_path = "/tmp/route_inspect_{}.png".format(int(_time.time()))
+
     dbu = _layout.dbu
     tolerance_dbu = int(round(tolerance_um / dbu))
 
@@ -1155,6 +1165,18 @@ def _tool_route_inspect(args):
             if area_um2 &gt; 0.01:
                 crossings.append([i, j, area_um2])
 
+    # Issue #34: labeled-crossings image. Only rendered when at least
+    # one crossing was detected — empty crossings short-circuits to
+    # image_path=None so the agent can branch on it.
+    image_path_out = None
+    if crossings:
+        try:
+            image_path_out = _render_route_inspect_crossings_image(
+                routes, crossings, labeled_image_path, dbu)
+        except Exception as _exc:
+            _log("route_inspect: labeled-crossings render failed: {}".format(_exc))
+            image_path_out = None
+
     # next_step_suggestion
     n_unmapped = sum(1 for r in out_routes if r["from_contact"] is None or r["to_pad"] is None)
     if crossings:
@@ -1171,8 +1193,158 @@ def _tool_route_inspect(args):
         "routes": out_routes,
         "crossings": crossings,
         "crossing_pairs_format": "[route_idx_A, route_idx_B, overlap_um2]",
+        "image_path": image_path_out,
         "next_step_suggestion": next_step,
     })
+
+
+def _render_route_inspect_crossings_image(routes, crossings, out_path, dbu):
+    """Render a labeled PNG showing each crossing-involved route's
+    route_id near both of its endpoints.
+
+    Issue #34 spec:
+      - Bbox = union of all crossing-involved route polygons
+        (both members of every crossing pair) + 10x line-width clearance.
+      - Render the layout in that bbox via the existing screenshot path
+        (LayoutView.zoom_box + save_image).
+      - Overlay each route's route_id as ``[&lt;id&gt;]`` near both endpoints
+        using pya.QImage + pya.QPainter (no external deps required).
+      - On any rendering failure, the caller catches and returns
+        image_path=None.
+    """
+    global _layout, _layout_view
+    if _layout_view is None:
+        return None
+
+    # Collect every route_id that participates in a crossing.
+    involved_ids = set()
+    for pair in crossings:
+        involved_ids.add(int(pair[0]))
+        involved_ids.add(int(pair[1]))
+
+    # Union bbox of all involved route polygons (DBU coordinates).
+    bbox_dbu = None
+    width_dbu_max = 0
+    for rid in involved_ids:
+        try:
+            poly = routes[rid]["polygon"]
+            bb = poly.bbox()
+            if bbox_dbu is None:
+                bbox_dbu = pya.Box(bb.left, bb.bottom, bb.right, bb.top)
+            else:
+                bbox_dbu = bbox_dbu + bb
+            # Effective line-width proxy: shorter edge of the route bbox.
+            edge = min(bb.width(), bb.height())
+            if edge &gt; width_dbu_max:
+                width_dbu_max = edge
+        except Exception:
+            continue
+    if bbox_dbu is None:
+        return None
+
+    # 10x line-width clearance.
+    pad_dbu = int(round(10 * max(width_dbu_max, int(round(1.0 / dbu)))))
+    x1_um = (bbox_dbu.left - pad_dbu) * dbu
+    y1_um = (bbox_dbu.bottom - pad_dbu) * dbu
+    x2_um = (bbox_dbu.right + pad_dbu) * dbu
+    y2_um = (bbox_dbu.top + pad_dbu) * dbu
+
+    width_px = 1024
+    height_px = 768
+    abs_path = os.path.abspath(out_path)
+
+    # Step 1: render the layout in the crossing bbox to a PNG.
+    _layout_view.zoom_box(pya.DBox(x1_um, y1_um, x2_um, y2_um))
+    _layout_view.save_image(abs_path, width_px, height_px)
+    _log("route_inspect: base PNG saved to {} (zoom_box=[{:.3f},{:.3f},{:.3f},{:.3f}])".format(
+        abs_path, x1_um, y1_um, x2_um, y2_um))
+
+    # Step 2: overlay route_id labels near each endpoint of every
+    # crossing-involved route.
+    try:
+        img = pya.QImage(abs_path)
+        if img.isNull():
+            _log("route_inspect: QImage failed to load saved PNG; returning unlabeled image")
+            return abs_path
+        painter = pya.QPainter(img)
+        try:
+            painter.setRenderHint(pya.QPainter.Antialiasing, True)
+        except Exception:
+            pass
+
+        # Coordinate transform: layout-um -&gt; image-pixel.
+        # save_image fits the zoom_box into the image; px_per_um is
+        # uniform along whichever axis fits, with letterboxing on the
+        # other. Use the *minimum* px-per-um of the two axes so that
+        # labels stay inside the rendered region.
+        u_w = x2_um - x1_um
+        u_h = y2_um - y1_um
+        if u_w &lt;= 0 or u_h &lt;= 0:
+            painter.end()
+            return abs_path
+        sx = width_px / u_w
+        sy = height_px / u_h
+        s_fit = min(sx, sy)
+        # Letterbox offsets (centre the bbox in the image).
+        ox = (width_px - u_w * s_fit) / 2.0
+        oy = (height_px - u_h * s_fit) / 2.0
+
+        def _to_px(x_um, y_um):
+            # Image y grows downward; layout y grows upward.
+            px = ox + (x_um - x1_um) * s_fit
+            py = height_px - (oy + (y_um - y1_um) * s_fit)
+            return px, py
+
+        # Label style: yellow text on a translucent black box for
+        # readability against any layer-stack background.
+        font = pya.QFont()
+        try:
+            font.setPointSize(11)
+            font.setBold(True)
+        except Exception:
+            pass
+        painter.setFont(font)
+        text_pen = pya.QPen(pya.QColor(255, 220, 0))
+        bg_brush = pya.QBrush(pya.QColor(0, 0, 0, 160))
+
+        for rid in sorted(involved_ids):
+            try:
+                ep_a, ep_b = routes[rid]["endpoints_dbu"]
+            except Exception:
+                continue
+            for ep in (ep_a, ep_b):
+                ux = ep[0] * dbu
+                uy = ep[1] * dbu
+                if ux &lt; x1_um or ux &gt; x2_um or uy &lt; y1_um or uy &gt; y2_um:
+                    # Endpoint outside the rendered bbox — skip.
+                    continue
+                px, py = _to_px(ux, uy)
+                label = "[{}]".format(rid)
+                # Draw small background rect behind the label for legibility.
+                fm = painter.fontMetrics()
+                try:
+                    tw = fm.horizontalAdvance(label)
+                except Exception:
+                    try:
+                        tw = fm.width(label)
+                    except Exception:
+                        tw = 30
+                try:
+                    th = fm.height()
+                except Exception:
+                    th = 16
+                pad = 3
+                bg_rect = pya.QRectF(px + 6, py - th - pad, tw + 2 * pad, th + 2 * pad)
+                painter.fillRect(bg_rect, bg_brush)
+                painter.setPen(text_pen)
+                painter.drawText(int(px + 6 + pad), int(py - pad), label)
+        painter.end()
+        img.save(abs_path)
+        _log("route_inspect: labeled {} crossing-involved route(s) in {}".format(
+            len(involved_ids), abs_path))
+    except Exception as _exc:
+        _log("route_inspect: label overlay failed (returning unlabeled image): {}".format(_exc))
+    return abs_path
 
 
 def _tool_evaluate_design(args):

--- a/plugin/klayoutclaw_server.lym
+++ b/plugin/klayoutclaw_server.lym
@@ -357,109 +357,11 @@ TOOLS = [
             }
         }
     },
-    {
-        "name": "vc_init",
-        "description": "Initialise version control for the current layout. mode='auto' detects sidecar (memory/disk), 'memory' forces tmpdir, 'disk' hard-requires writable sidecar (no silent fallback).",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "mode": {"type": "string", "enum": ["auto", "memory", "disk"], "default": "auto", "description": "Repo mode. auto=detect (disk if sidecar exists, memory otherwise); memory=force tmpdir; disk=hard-require writable sidecar."},
-                "gds_path": {"type": "string", "description": "Absolute path to the .gds file this VC repo is associated with. Required."}
-            },
-            "required": ["gds_path"]
-        }
-    },
-    {
-        "name": "vc_checkpoint",
-        "description": "Create a version-control checkpoint (commit) of the current layout. Returns {ok, sha, ts} on success.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "message": {"type": "string", "description": "Human-readable commit message."},
-                "tags": {"type": "array", "items": {"type": "string"}, "description": "Optional list of tag names to apply to the new commit."}
-            },
-            "required": ["message"]
-        }
-    },
-    {
-        "name": "vc_history",
-        "description": "List checkpoint history. Returns {ok, commits:[{sha, message, ts, tags, branch, stats}, ...]}.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "limit": {"type": "integer", "description": "Maximum number of commits to return (most recent first)."},
-                "branch": {"type": "string", "description": "Optional branch name; defaults to HEAD."}
-            }
-        }
-    },
-    {
-        "name": "vc_checkout",
-        "description": "Restore the layout to a prior checkpoint. Moves sidecar HEAD AND rewrites the in-memory layout to match. Returns {ok, sha}.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "ref": {"type": "string", "description": "Commit sha, tag, or branch name to checkout."}
-            },
-            "required": ["ref"]
-        }
-    },
-    {
-        "name": "vc_diff",
-        "description": "Compare two checkpoints by polygon-level delta. Returns added_polygons, removed_polygons, moved_polygons, layer_stats, bbox_delta, polygon_count_delta.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "ref_a": {"type": "string", "description": "Base reference (sha/tag/branch)."},
-                "ref_b": {"type": "string", "description": "Target reference (sha/tag/branch)."}
-            },
-            "required": ["ref_a", "ref_b"]
-        }
-    },
-    {
-        "name": "vc_branch",
-        "description": "Branch operations: list, create, switch, merge. Unknown ops are rejected with ok=False.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "op": {"type": "string", "enum": ["list", "create", "switch", "merge"], "description": "Branch op to perform."},
-                "name": {"type": "string", "description": "Branch name (required for create/switch/merge)."},
-                "from_ref": {"type": "string", "description": "Optional starting ref for 'create'."}
-            },
-            "required": ["op"]
-        }
-    },
-    {
-        "name": "vc_tag",
-        "description": "Create an annotated tag at a ref (default HEAD). Duplicate tag names return ok=False with 'already exists'.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string", "description": "Tag name."},
-                "ref": {"type": "string", "description": "Optional ref to tag (default HEAD)."}
-            },
-            "required": ["name"]
-        }
-    },
-    {
-        "name": "vc_export",
-        "description": "Export a checkpoint's layout as GDS bytes (base64-inlined) or pya code. Payloads over 256 KiB are written to a tempfile and returned via path=, with truncated=True.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "ref": {"type": "string", "description": "Commit sha / tag / branch to export."},
-                "format": {"type": "string", "enum": ["gds", "pya"], "description": "Export format. 'gds'=base64 GDS bytes; 'pya'=executable klayout.db Python code."}
-            },
-            "required": ["ref", "format"]
-        }
-    },
-    {
-        "name": "vc_status",
-        "description": "Report the live VC status. Returns {ok, branch, dirty, last_checkpoint_ts, pending, mode}. Uninitialised layouts return ok=False with reason='vc not initialized'.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {}
-        }
-    }
+    # NOTE: vc_* tools (vc_init, vc_checkpoint, vc_history, vc_checkout,
+    # vc_diff, vc_branch, vc_tag, vc_export, vc_status) intentionally
+    # de-advertised here per issue #25 (review session 2026-05-05). The
+    # corresponding _TOOL_DISPATCH entries are also stripped; the handler
+    # functions remain defined below in case this off-switch is reverted.
 ]
 
 
@@ -1846,15 +1748,12 @@ _TOOL_DISPATCH = {
     "evaluate_design": _tool_evaluate_design,
     "validate_pixel_size": _tool_validate_pixel_size,
     "close_layout_view": _tool_close_layout_view,
-    "vc_init": _tool_vc_init,
-    "vc_checkpoint": _tool_vc_checkpoint,
-    "vc_history": _tool_vc_history,
-    "vc_checkout": _tool_vc_checkout,
-    "vc_diff": _tool_vc_diff,
-    "vc_branch": _tool_vc_branch,
-    "vc_tag": _tool_vc_tag,
-    "vc_export": _tool_vc_export,
-    "vc_status": _tool_vc_status,
+    # NOTE: vc_* tools intentionally not registered (issue #25 — review
+    # session 2026-05-05). Server-side off-switch: vc_init was the
+    # confirmed hang trigger, and stripping the dispatch entries is the
+    # cheapest way to ensure tools/call cannot reach the vc_* handlers.
+    # The handler functions (_tool_vc_init etc.) are kept defined above
+    # in case the off-switch is reverted.
 }
 
 

--- a/tests/test_phase1_no_vc.py
+++ b/tests/test_phase1_no_vc.py
@@ -1,0 +1,70 @@
+"""Issue #25 — verify vc_* tools are stripped from MCP server.
+
+Static smoke test: parse ``plugin/klayoutclaw_server.lym`` and assert that
+neither the ``_TOOL_DISPATCH`` dict nor the ``TOOLS`` (tools/list payload)
+list advertises any ``vc_*`` name.
+
+Deterministic + fast — does not require a running KLayout MCP server.
+
+Issue context: review session 2026-05-05 elected a server-side off-switch
+for the version-control tools (``vc_init`` was the only confirmed hang
+trigger) by stripping them from ``_TOOL_DISPATCH``. ``tools/list`` is
+required to not advertise them either.
+"""
+from __future__ import annotations
+
+import ast
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LYM_PATH = REPO_ROOT / "plugin" / "klayoutclaw_server.lym"
+
+
+def _load_python_source() -> str:
+    """Extract the embedded Python from the .lym XML wrapper."""
+    tree = ET.parse(LYM_PATH)
+    root = tree.getroot()
+    text_el = root.find("text")
+    assert text_el is not None and text_el.text, (
+        f"klayoutclaw_server.lym has no <text> element: {LYM_PATH}"
+    )
+    return text_el.text
+
+
+@pytest.fixture(scope="module")
+def server_source() -> str:
+    return _load_python_source()
+
+
+def test_server_source_is_valid_python(server_source: str):
+    ast.parse(server_source)
+
+
+def test_tool_dispatch_has_no_vc_keys(server_source: str):
+    """``_TOOL_DISPATCH`` must not contain any ``vc_*`` key."""
+    m = re.search(r"_TOOL_DISPATCH\s*=\s*\{(.*?)\n\}", server_source, re.S)
+    assert m, "Could not locate _TOOL_DISPATCH = { ... } block in server source"
+    block = m.group(1)
+    # Match string keys in the dispatch dict, e.g. "vc_init":
+    leaked = re.findall(r'"(vc_[A-Za-z_]+)"\s*:', block)
+    assert not leaked, (
+        f"_TOOL_DISPATCH still advertises vc_* tools: {leaked}. Issue #25 "
+        f"requires these be stripped (server-side off-switch)."
+    )
+
+
+def test_tools_list_payload_has_no_vc_entries(server_source: str):
+    """The ``TOOLS`` list (tools/list payload) must not advertise vc_*."""
+    m = re.search(r"\nTOOLS\s*=\s*\[(.*?)\n\]\n", server_source, re.S)
+    assert m, "Could not locate TOOLS = [ ... ] block in server source"
+    block = m.group(1)
+    leaked = re.findall(r'"name"\s*:\s*"(vc_[A-Za-z_]+)"', block)
+    assert not leaked, (
+        f"tools/list still advertises vc_* tools: {leaked}. Issue #25 "
+        f"requires these be removed (no advertisement, no dispatch)."
+    )

--- a/tests/test_phase5_vc_tools_list.py
+++ b/tests/test_phase5_vc_tools_list.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-"""qlaybot v0.4.4 Phase 5 Task 5.10 (plugin-side half) — tools/list regression.
+"""Phase 5 + Issue #25 — vc_* tools must NOT be advertised by tools/list.
 
-Verifies that the KLayout MCP server (``plugin/klayoutclaw_server.lym``),
-after the Executor registers the 9 Phase 5 VC handlers, exposes them in
-its ``tools/list`` response.
+Originally this test (Phase 5 Task 5.10) asserted that the MCP server
+exposed all 9 ``vc_*`` handlers in its ``tools/list`` response. Issue #25
+(review session 2026-05-05) inverted that contract: ``vc_init`` was the
+only confirmed hang trigger, and the cheapest mitigation is a server-side
+off-switch — strip the ``vc_*`` entries from ``_TOOL_DISPATCH`` and from
+the advertised ``TOOLS`` list. The handler module
+``tools/vc_mcp_handlers`` is still imported and unit-tested separately
+(see ``test_phase5_vc_handlers.py``); only the MCP advertisement has been
+removed.
 
-Auto-skips when the MCP server is not reachable (same pattern as
-``tests/test_phase4_mcp.py``).  Run under the project's root pytest.
+Auto-skips when the MCP server is not reachable.
 """
 from __future__ import annotations
 
@@ -19,7 +24,7 @@ import pytest
 
 MCP_URL = "http://127.0.0.1:8765/mcp"
 
-_EXPECTED_VC_BARE_NAMES = [
+_FORBIDDEN_VC_NAMES = [
     "vc_init",
     "vc_checkpoint",
     "vc_history",
@@ -84,7 +89,7 @@ def _mcp_init_session():
     _mcp_call("initialize", {
         "protocolVersion": "2025-03-26",
         "capabilities": {},
-        "clientInfo": {"name": "test_phase5_vc_tools_list", "version": "0.1"},
+        "clientInfo": {"name": "test_phase5_vc_tools_list", "version": "0.2"},
     })
     yield
 
@@ -98,38 +103,21 @@ def _get_tool_names():
     return [t["name"] for t in tools]
 
 
-class TestPhase5VcToolsRegistered:
-    def test_all_9_vc_tools_in_tools_list(self):
-        """Plugin must register all 9 vc_* handlers in the MCP dispatch map."""
+class TestIssue25VcToolsStripped:
+    def test_no_vc_tools_in_tools_list(self):
+        """Issue #25: the MCP server must not advertise any vc_* tool."""
         names = _get_tool_names()
-        missing = [n for n in _EXPECTED_VC_BARE_NAMES if n not in names]
-        assert not missing, (
-            f"The following vc_* tools are missing from MCP tools/list: "
-            f"{missing}. Full tool list: {sorted(names)}"
+        leaked = [n for n in names if n in _FORBIDDEN_VC_NAMES]
+        assert not leaked, (
+            f"vc_* tools are still advertised by tools/list: {leaked}. "
+            f"Issue #25 requires these be stripped."
         )
 
-    def test_each_vc_tool_has_valid_schema(self):
-        """Each vc_* tool must have a valid JSON-Schema 'inputSchema' object."""
-        resp = _mcp_call("tools/list")
-        tools = {t["name"]: t for t in resp["result"]["tools"]}
-        for bare in _EXPECTED_VC_BARE_NAMES:
-            assert bare in tools, (
-                f"vc_* tool {bare!r} missing from tools/list"
-            )
-            tool = tools[bare]
-            schema = tool.get("inputSchema")
-            assert isinstance(schema, dict) and schema.get("type") == "object", (
-                f"tool {bare!r} must have inputSchema type=object, got {schema!r}"
-            )
-
-    def test_vc_init_requires_gds_path(self):
-        """vc_init inputSchema must mark ``gds_path`` as required."""
-        resp = _mcp_call("tools/list")
-        tools = {t["name"]: t for t in resp["result"]["tools"]}
-        init_tool = tools.get("vc_init")
-        assert init_tool is not None, "vc_init missing from tools/list"
-        schema = init_tool["inputSchema"]
-        required = schema.get("required", [])
-        assert "gds_path" in required, (
-            f"vc_init must require gds_path, got required={required!r}"
+    def test_no_name_starts_with_vc_(self):
+        """Defense in depth: no advertised tool name may start with 'vc_'."""
+        names = _get_tool_names()
+        leaked = [n for n in names if n.startswith("vc_")]
+        assert not leaked, (
+            f"Tool names beginning with 'vc_' must not be advertised: "
+            f"{leaked}."
         )

--- a/tests/test_route_inspect_image.py
+++ b/tests/test_route_inspect_image.py
@@ -1,0 +1,278 @@
+"""Issue #34 — route_inspect labeled-crossings image.
+
+Two tiers of test:
+
+1. **Static** (no KLayout required) — parses the .lym source and asserts
+   that the ``image_path`` arg is wired through the schema, the
+   helper ``_render_route_inspect_crossings_image`` exists, and the
+   tool returns ``image_path`` in its JSON envelope.
+2. **Snapshot** (requires running KLayout MCP server) — synthesises a
+   small layout with two intentionally crossing routes, calls
+   ``route_inspect`` via MCP, and asserts the returned ``image_path``
+   resolves to a non-empty PNG. Skips when MCP is not reachable.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LYM_PATH = REPO_ROOT / "plugin" / "klayoutclaw_server.lym"
+MCP_URL = "http://127.0.0.1:8765/mcp"
+
+
+def _server_source() -> str:
+    text = ET.parse(LYM_PATH).getroot().find("text").text
+    assert text, "klayoutclaw_server.lym <text> empty"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: static structure tests
+# ---------------------------------------------------------------------------
+
+def test_route_inspect_schema_advertises_image_path():
+    src = _server_source()
+    # Find the route_inspect TOOLS entry and check image_path appears in it.
+    m = re.search(
+        r'"name":\s*"route_inspect".*?"required":\s*\[[^\]]+\]\s*\}\s*\}',
+        src, re.S,
+    )
+    assert m, "Could not locate route_inspect TOOLS entry"
+    block = m.group(0)
+    assert '"image_path"' in block, (
+        "route_inspect schema is missing the 'image_path' property "
+        "(issue #34). Block snippet:\n" + block[:600]
+    )
+
+
+def test_render_helper_defined():
+    src = _server_source()
+    assert "def _render_route_inspect_crossings_image(" in src, (
+        "Expected helper _render_route_inspect_crossings_image() to be "
+        "defined in klayoutclaw_server.lym (issue #34)."
+    )
+
+
+def test_route_inspect_returns_image_path_field():
+    src = _server_source()
+    # The return-dict in _tool_route_inspect must include the new key.
+    m = re.search(r"def _tool_route_inspect\(args\):(.+?)\ndef ", src, re.S)
+    assert m, "Could not locate _tool_route_inspect body"
+    body = m.group(1)
+    assert '"image_path": image_path_out' in body, (
+        "_tool_route_inspect must include 'image_path' in its JSON return "
+        "(issue #34). Got body tail:\n" + body[-800:]
+    )
+
+
+def test_no_crossings_yields_null_image_path():
+    """Ensure the rendering call is gated on `if crossings:`."""
+    src = _server_source()
+    m = re.search(
+        r"image_path_out = None\s*\n\s*if crossings:",
+        src,
+    )
+    assert m, (
+        "Expected `image_path_out = None` followed by `if crossings:` "
+        "guard so the empty-crossings case returns image_path=null."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: live MCP snapshot test (skips when server is down)
+# ---------------------------------------------------------------------------
+
+def _mcp_available() -> bool:
+    try:
+        payload = json.dumps({"jsonrpc": "2.0", "id": 0, "method": "ping"}).encode()
+        req = urllib.request.Request(
+            MCP_URL, data=payload,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        urllib.request.urlopen(req, timeout=2)
+        return True
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def _plugin_supports_image_path() -> bool:
+    """The running KLayout plugin must be the issue-#34 build."""
+    if not _mcp_available():
+        return False
+    try:
+        payload = json.dumps({
+            "jsonrpc": "2.0", "id": 0, "method": "tools/list",
+        }).encode()
+        req = urllib.request.Request(
+            MCP_URL, data=payload,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        r = urllib.request.urlopen(req, timeout=2)
+        data = json.loads(r.read().decode())
+        for t in data.get("result", {}).get("tools", []):
+            if t.get("name") == "route_inspect":
+                props = (t.get("inputSchema") or {}).get("properties", {})
+                return "image_path" in props
+        return False
+    except Exception:
+        return False
+
+
+_session_id = None
+_req_id = 0
+
+
+def _mcp_call(method, params=None, timeout=30):
+    global _req_id, _session_id
+    _req_id += 1
+    body = {"jsonrpc": "2.0", "id": _req_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    headers = {"Content-Type": "application/json"}
+    if _session_id:
+        headers["Mcp-Session-Id"] = _session_id
+    req = urllib.request.Request(
+        MCP_URL, data=json.dumps(body).encode(),
+        headers=headers, method="POST",
+    )
+    r = urllib.request.urlopen(req, timeout=timeout)
+    _session_id = r.headers.get("Mcp-Session-Id", _session_id)
+    data = json.loads(r.read().decode())
+    if "error" in data:
+        raise RuntimeError(f"MCP error: {data['error']}")
+    return data
+
+
+@pytest.mark.mcp
+@pytest.mark.skipif(
+    not _plugin_supports_image_path(),
+    reason="Running KLayout plugin lacks issue-#34 image_path schema; reinstall plugin",
+)
+def test_route_inspect_image_snapshot(tmp_path):
+    """Live snapshot: synthesise crossing routes, call route_inspect, verify
+    the returned image_path resolves to a non-empty PNG."""
+    # Initialise + create a fresh layout.
+    _mcp_call("initialize", {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "test_route_inspect_image", "version": "0.1"},
+    })
+    _mcp_call("tools/call", {
+        "name": "create_layout",
+        "arguments": {"name": "TOP_RI", "dbu": 0.001},
+    })
+
+    # Build a minimal scene via execute_script:
+    # - two routes on layer 3/0 that overlap (crossing)
+    # - one contact polygon on 1/0 near each route start
+    # - one pad polygon on 2/0 near each route end
+    out_png = str(tmp_path / "labeled.png")
+    setup_script = (
+        "from pya import DPath, DPolygon, DPoint, DBox\n"
+        "L_route, _ = _layout, _top_cell\n"
+        "li_r = _layout.layer(3, 0)\n"
+        "li_c = _layout.layer(1, 0)\n"
+        "li_p = _layout.layer(2, 0)\n"
+        "# Route A: horizontal\n"
+        "_top_cell.shapes(li_r).insert(DPath([DPoint(0, 50), DPoint(200, 50)], 4.0))\n"
+        "# Route B: vertical, crosses A\n"
+        "_top_cell.shapes(li_r).insert(DPath([DPoint(100, -50), DPoint(100, 150)], 4.0))\n"
+        "# Contacts (layer 1) at the start of each route\n"
+        "_top_cell.shapes(li_c).insert(DBox(-6, 44, 4, 56))\n"
+        "_top_cell.shapes(li_c).insert(DBox(94, -56, 106, -44))\n"
+        "# Pads (layer 2) at the end of each route\n"
+        "_top_cell.shapes(li_p).insert(DBox(196, 44, 206, 56))\n"
+        "_top_cell.shapes(li_p).insert(DBox(94, 144, 106, 156))\n"
+        "result = {'ok': True}\n"
+    )
+    _mcp_call("tools/call", {
+        "name": "execute_script",
+        "arguments": {"code": setup_script},
+    })
+
+    resp = _mcp_call("tools/call", {
+        "name": "route_inspect",
+        "arguments": {
+            "route_layer": "3/0",
+            "contact_layers": ["1/0"],
+            "pad_layer": "2/0",
+            "tolerance_um": 10.0,
+            "image_path": out_png,
+        },
+    })
+    text = resp["result"]["content"][0]["text"]
+    payload = json.loads(text)
+    assert payload["status"] == "ok", payload
+    assert payload["crossings"], (
+        "Expected at least one crossing in the synthesised scene; got "
+        f"crossings={payload['crossings']!r}"
+    )
+    img = payload["image_path"]
+    assert img is not None, "image_path must be set when crossings exist"
+    assert os.path.isfile(img), f"image_path does not exist on disk: {img}"
+    assert os.path.getsize(img) > 1024, (
+        f"labeled crossings PNG is suspiciously small ({os.path.getsize(img)} bytes)"
+    )
+
+
+@pytest.mark.mcp
+@pytest.mark.skipif(
+    not _plugin_supports_image_path(),
+    reason="Running KLayout plugin lacks issue-#34 image_path schema; reinstall plugin",
+)
+def test_route_inspect_no_crossings_yields_null_image(tmp_path):
+    """Live snapshot: layout with no crossings should return image_path=null."""
+    _mcp_call("initialize", {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "test_route_inspect_image", "version": "0.1"},
+    })
+    _mcp_call("tools/call", {
+        "name": "create_layout",
+        "arguments": {"name": "TOP_RI_NX", "dbu": 0.001},
+    })
+    setup_script = (
+        "from pya import DPath, DPoint, DBox\n"
+        "li_r = _layout.layer(3, 0)\n"
+        "li_c = _layout.layer(1, 0)\n"
+        "li_p = _layout.layer(2, 0)\n"
+        "# Two parallel non-crossing routes\n"
+        "_top_cell.shapes(li_r).insert(DPath([DPoint(0, 50), DPoint(200, 50)], 4.0))\n"
+        "_top_cell.shapes(li_r).insert(DPath([DPoint(0, 100), DPoint(200, 100)], 4.0))\n"
+        "_top_cell.shapes(li_c).insert(DBox(-6, 44, 4, 56))\n"
+        "_top_cell.shapes(li_c).insert(DBox(-6, 94, 4, 106))\n"
+        "_top_cell.shapes(li_p).insert(DBox(196, 44, 206, 56))\n"
+        "_top_cell.shapes(li_p).insert(DBox(196, 94, 206, 106))\n"
+        "result = {'ok': True}\n"
+    )
+    _mcp_call("tools/call", {
+        "name": "execute_script",
+        "arguments": {"code": setup_script},
+    })
+    resp = _mcp_call("tools/call", {
+        "name": "route_inspect",
+        "arguments": {
+            "route_layer": "3/0",
+            "contact_layers": ["1/0"],
+            "pad_layer": "2/0",
+            "tolerance_um": 10.0,
+        },
+    })
+    text = resp["result"]["content"][0]["text"]
+    payload = json.loads(text)
+    assert payload["status"] == "ok"
+    assert payload["crossings"] == [], (
+        f"Expected no crossings, got {payload['crossings']!r}"
+    )
+    assert payload["image_path"] is None, (
+        f"Expected image_path=null when no crossings; got {payload['image_path']!r}"
+    )


### PR DESCRIPTION
Closes #25. Closes #34.

## Issue #25 — strip `vc_*` from `_TOOL_DISPATCH`

Per the 2026-05-05 review session, the 9 `vc_*` MCP tools (`vc_init`, `vc_checkpoint`, `vc_history`, `vc_checkout`, `vc_diff`, `vc_branch`, `vc_tag`, `vc_export`, `vc_status`) are de-emphasized as a server-side off-switch — `vc_init` was the only confirmed hang trigger, and stripping the dispatch + advertisement entries is the cheapest mitigation. The `_tool_vc_*` handler functions remain defined in case the off-switch is reverted, and `tools.vc_mcp_handlers` is still unit-tested via `test_phase5_vc_handlers.py`. The Phase 5 `tools/list` test was inverted to assert the new contract (no `vc_*` advertisement).

## Issue #34 — `route_inspect` labeled-crossings image

Recasts the original "route name field" enhancement as a visualization tool. When crossings are detected, `route_inspect` now renders a labeled PNG of the crossing region: bbox is the union of all crossing-involved route polygon bboxes padded by 10x line-width clearance, rendered via the existing `LayoutView.zoom_box + save_image` path, then `pya.QImage + pya.QPainter` overlays each crossing-involved route's `route_id` as `[<id>]` near both endpoints (yellow on translucent black for legibility against any layer stack). The new `image_path` arg defaults to `/tmp/route_inspect_<ts>.png`; explicit paths are honoured. No-crossings short-circuits to `image_path: null` so the agent can branch on it. No new external dependencies — `pya.QImage` / `pya.QPainter` are already used by the VC UI thumbnail.

## Test plan
- [x] `tests/test_phase1_no_vc.py` (3 tests) — fast static check that `_TOOL_DISPATCH` and `TOOLS` carry no `vc_*` entries; AST-parses the embedded Python.
- [x] `tests/test_phase5_vc_tools_list.py` — inverted: `tools/list` must NOT advertise `vc_*`.
- [x] `tests/test_route_inspect_image.py` — 4 static tests + 2 live MCP snapshot tests (synthesised crossing scene; auto-skip when running plugin lacks the `image_path` schema). Static tests pass; live tests skip cleanly until plugin is reinstalled.
- [ ] Reinstall plugin and run live snapshot tests in KLayout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)