### PR TITLE
fix: #36 PLANNER, NOT EXECUTOR prefix on planner tool descriptions

### DIFF
--- a/agent/src/tools/klayout/nanodevice.ts
+++ b/agent/src/tools/klayout/nanodevice.ts
@@ -101,6 +101,7 @@ function registerFlakedetectTools(): CodeGenTool[] {
       "nanodevice_flakedetect",
       "align",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Register source microscope images to the full_stack coordinate system.",
         "Uses SIFT for same-substrate alignment (bottom→full_stack) and",
         "Chamfer+DE for cross-substrate alignment (top PDMS→full_stack SiO2).",
@@ -169,6 +170,7 @@ function registerFlakedetectTools(): CodeGenTool[] {
       "nanodevice_flakedetect",
       "detect",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Detect individual material layers from their optimal source images.",
         "Runs 4 independent detections: graphite (bottom_part), graphene (top_part),",
         "bottom_hBN (bottom_part + SIFT warp to full_stack), top_hBN (footprint copy).",
@@ -225,6 +227,7 @@ function registerFlakedetectTools(): CodeGenTool[] {
       "nanodevice_flakedetect",
       "combine",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Transform per-material detections into the full_stack coordinate system,",
         "build unified traces.json, and draw overlay visualizations.",
         "Use after align and detect steps are both complete.",
@@ -274,6 +277,7 @@ function registerFlakedetectTools(): CodeGenTool[] {
       "nanodevice_flakedetect",
       "commit",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Insert detected material polygons into KLayout from traces.json.",
         "Loads background image, transforms coordinates (image→KLayout),",
         "and inserts polygons on layers 10-13/0.",
@@ -322,6 +326,7 @@ function registerFlakedetectTools(): CodeGenTool[] {
       "nanodevice_flakedetect",
       "review",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Validate committed flake polygons in KLayout via visual inspection.",
         "Isolates each material layer, takes screenshots, compares with combine",
         "overlays, and produces a PASS/FAIL verdict.",
@@ -373,6 +378,7 @@ function registerGdsalignTools(): CodeGenTool[] {
       "nanodevice_gdsalign",
       "align_to_gds",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Align microscope stack images to a GDS fabrication template using",
         "lithographic marker detection. Computes image→GDS similarity transform",
         "and commits warped image + material contours to KLayout.",
@@ -436,6 +442,7 @@ function registerRoutingTools(): CodeGenTool[] {
       "nanodevice_routing",
       "place_pads",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Place bonding pads in a regular pattern around the device perimeter.",
         "Creates pads on a specified layer and places pin markers for routing.",
         "Use after device geometry is created and before routing leads.",
@@ -470,6 +477,7 @@ function registerRoutingTools(): CodeGenTool[] {
       "nanodevice_routing",
       "route_leads",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Route leads from device contact pins to bonding pad pins using multi-window",
         "EBL support. Inner window uses fine lines, outer window uses coarse lines,",
         "with boundary patches for connectivity.",
@@ -516,6 +524,7 @@ function registerRoutingTools(): CodeGenTool[] {
       "nanodevice_routing",
       "clear_routes",
       [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Remove all routing geometry from specified layers.",
         "Use to clear failed routes before re-routing with adjusted parameters.",
       ].join(" "),

--- a/agent/src/tools/klayout/visual.ts
+++ b/agent/src/tools/klayout/visual.ts
@@ -29,6 +29,7 @@ export function registerVisualTools(): CodeGenTool[] {
       serverKey: PREFIX,
       group: GROUP,
       description: [
+        "**PLANNER, NOT EXECUTOR.** Returns a `workflow_plan` listing bash commands you must run yourself (via the bash tool).",
         "Return a workflow_plan for rendering the full KLayout GDS layout as a PNG",
         "using gdstk + matplotlib (per-layer colors, legend, DPI control). This tool",
         "does NOT execute the render — it returns a plan that the agent must run",

--- a/agent/tests/test-issue-36-planner-prefix.ts
+++ b/agent/tests/test-issue-36-planner-prefix.ts
@@ -1,0 +1,38 @@
+/**
+ * Issue #36 regression test.
+ *
+ * Every domain tool description in `agent/src/tools/klayout/nanodevice.ts`
+ * and `agent/src/tools/klayout/visual.ts` must begin with the literal
+ * sentence "**PLANNER, NOT EXECUTOR.**" so the LLM understands these tools
+ * only emit a workflow_plan — they do not execute anything themselves.
+ */
+
+import { describe, it, expect } from "vitest";
+import { registerNanodeviceTools } from "../src/tools/klayout/nanodevice.js";
+import { registerVisualTools } from "../src/tools/klayout/visual.js";
+
+const PLANNER_PREFIX = "**PLANNER, NOT EXECUTOR.**";
+
+describe("issue #36 — PLANNER, NOT EXECUTOR prefix", () => {
+  it("every nanodevice tool description starts with the planner prefix", () => {
+    const tools = registerNanodeviceTools();
+    expect(tools.length).toBeGreaterThan(0);
+    for (const tool of tools) {
+      expect(
+        tool.description?.startsWith(PLANNER_PREFIX),
+        `nanodevice tool ${tool.name} description must start with "${PLANNER_PREFIX}", got: ${tool.description?.slice(0, 60)}…`,
+      ).toBe(true);
+    }
+  });
+
+  it("every visual tool description starts with the planner prefix", () => {
+    const tools = registerVisualTools();
+    expect(tools.length).toBeGreaterThan(0);
+    for (const tool of tools) {
+      expect(
+        tool.description?.startsWith(PLANNER_PREFIX),
+        `visual tool ${tool.name} description must start with "${PLANNER_PREFIX}", got: ${tool.description?.slice(0, 60)}…`,
+      ).toBe(true);
+    }
+  });
+});

--- a/agent/vitest.files.ts
+++ b/agent/vitest.files.ts
@@ -31,6 +31,7 @@ export const unitFiles = [
   "tests/test-t16-graceful-degradation.ts",
   "tests/test-plan-reinjection.ts",
   "tests/test-thinking-only.ts",
+  "tests/test-issue-36-planner-prefix.ts",
 ];
 
 export const integrationFiles = [


### PR DESCRIPTION
Closes #36.

Every domain tool in `agent/src/tools/klayout/nanodevice.ts` (9 tools: flakedetect align/detect/combine/commit/review, gdsalign align_to_gds, routing place_pads/route_leads/clear_routes) and `agent/src/tools/klayout/visual.ts` (1 tool: visual_capture) now has its description prefixed with `**PLANNER, NOT EXECUTOR.** Returns a workflow_plan listing bash commands you must run yourself (via the bash tool).` so the LLM correctly recognises these as planners rather than executors. Build (`npm run build`) compiled clean; targeted regression test `agent/tests/test-issue-36-planner-prefix.ts` (registered in `agent/vitest.files.ts`) passes 2/2 assertions confirming both files. Per-instructions, the full `npm test` suite was deliberately not run because it would touch the live KLayout MCP server on :8765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)